### PR TITLE
add: seeFriendlyInvisibles meta config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,14 @@ Allows for player comparison using [placeholders](https://placeholders.pb4.eu/us
 ## Features
 This mod sends fake vanilla teams to the players in order to manipulate the displayed player list order. If you are using teams to change player collisions, nametag / glow color or nameTagVisibility you can use [meta keys](https://luckperms.net/wiki/Meta-Commands) to replicate this behaviour.
 
-| Meta Key       	 | Description                                                                                                  	                | Default 	 |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------|-----------|
-| color          	 | This is used for glow and nametag color (use [Color Codes](https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes)) 	 | `reset` 	 |
-| collision      	 | Player collisions are calculated client side, if you wish to disable player collisions, set this to `false`  	                | `true`  	 |
-| nameTagVisible 	 | Whether or not nametags should be displayed above the player                                                 	                | `true`  	 |
-| prefix 	         | Team prefix used for nametag rendering                                                 	                                      | `""`  	   |
-| suffix 	         | Team suffix used for nametag rendering                                                 	                                      | `""`  	   |
+| Meta Key       	        | Description                                                                                                  	                                      | Default 	  |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|------------|
+| color          	        | This is used for glow and nametag color (use [Color Codes](https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes)) 	                       | `reset` 	  |
+| collision      	        | Player collisions are calculated client side, if you wish to disable player collisions, set this to `false`  	                                      | `true`  	  |
+| nameTagVisible 	        | Whether or not nametags should be displayed above the player                                                 	                                      | `true`  	  |
+| seeFriendlyInvisibles 	 | When enabled players render themselves transparent, when they have the invisibility status effect                                                 	 | `false`  	 |
+| prefix 	                | Team prefix used for nametag rendering                                                 	                                                            | `""`  	    |
+| suffix 	                | Team suffix used for nametag rendering                                                 	                                                            | `""`  	    |
 
 
 ## Limitations

--- a/src/main/java/me/drex/orderedplayerlist/util/DummyTeam.java
+++ b/src/main/java/me/drex/orderedplayerlist/util/DummyTeam.java
@@ -49,6 +49,11 @@ public class DummyTeam extends PlayerTeam {
             modified = true;
             setNameTagVisibility(visibility);
         }
+        boolean seeFriendlyInvisibles = Options.get(player, "seeFriendlyInvisibles", false, Boolean::parseBoolean);
+        if (seeFriendlyInvisibles != canSeeFriendlyInvisibles()) {
+            modified = true;
+            setSeeFriendlyInvisibles(seeFriendlyInvisibles);
+        }
         if (Config.INSTANCE.displayPrefix) {
             Component prefix = Options.get(player, "prefix", Component.empty(), TextParserUtils::formatText);
             if (!prefix.equals(getPlayerPrefix())) {


### PR DESCRIPTION
Adds a meta config option for the `seeFriendlyInvisibles` options in teams.

This option is turned on by default in vanilla, causing every player in a team to render themselves as transparent when invisible, because they are in the same team. 

Outside of teams the player skin would normally render completely invisible, but since OPL puts everyone in their own team this makes them always render themselves as transparent instead. This is also my reason for setting the default to false, as it would match vanilla - without teams - behavior.